### PR TITLE
添加在 GitHub 中查看本页链接功能

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -35,6 +35,9 @@ jobs:
         with:
           source: ./
           destination: ./_site
+        env:
+          JEKYLL_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          JEKYLL_REPOSITORY: ${{ github.repository }}
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -298,6 +298,10 @@
         document.addEventListener('DOMContentLoaded', (event) => {
             document.querySelectorAll('a[href*=".md"]').forEach(link => {
                 const url = new URL(link.href);
+                // 跳过 GitHub 链接
+                if (url.hostname === 'github.com') {
+                    return;
+                }
                 if (url.pathname.endsWith('/readme.md')) {
                     url.pathname = url.pathname.replace(/readme\.md$/, '');
                 } else {

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -236,7 +236,11 @@
     <div class="footer">
         &copy; {{ site.time | date: '%Y' }}. All rights reserved.
         <br>
-        <a href="https://github.com/YouXam" target="_blank">Youxam</a>
+        <a href="https://github.com/YouXam" target="_blank">YouXam</a>
+        {% if site.github.repository_url %}
+        |
+        <a href="{{ site.github.repository_url }}/blob/{{ site.github.source.branch }}{{ page.path }}" target="_blank">在 Github 中查看本页</a>
+        {% endif %}
     </div>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/anchor-js/5.0.0/anchor.min.js"
         integrity="sha512-byAcNWVEzFfu+tZItctr+WIMUJvpzT2kokkqcBq+VsrM3OrC5Aj9E2gh+hHpU0XNA3wDmX4sDbV5/nkhvTrj4w=="

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -239,7 +239,11 @@
         <a href="https://github.com/YouXam" target="_blank">YouXam</a>
         {% if site.github.repository_url %}
         |
-        <a href="{{ site.github.repository_url }}/blob/{{ site.github.source.branch }}/{{ page.path }}" target="_blank">在 Github 中查看本页</a>
+        {% assign github_path = page.path %}
+        {% if page.path contains '.html' %}
+          {% assign github_path = page.path | replace: '.html', '.md' %}
+        {% endif %}
+        <a href="{{ site.github.repository_url }}/blob/{{ site.github.source.branch }}/{{ github_path }}" target="_blank">在 Github 中查看本页</a>
         {% endif %}
     </div>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/anchor-js/5.0.0/anchor.min.js"

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -239,7 +239,7 @@
         <a href="https://github.com/YouXam" target="_blank">YouXam</a>
         {% if site.github.repository_url %}
         |
-        <a href="{{ site.github.repository_url }}/blob/{{ site.github.source.branch }}{{ page.path }}" target="_blank">在 Github 中查看本页</a>
+        <a href="{{ site.github.repository_url }}/blob/{{ site.github.source.branch }}/{{ page.path }}" target="_blank">在 Github 中查看本页</a>
         {% endif %}
     </div>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/anchor-js/5.0.0/anchor.min.js"


### PR DESCRIPTION
## 🎯 功能描述

添加了在每个页面底部显示"在 GitHub 中查看本页"的链接功能，方便用户直接跳转到 GitHub 查看和编辑对应的源文件。

## 📋 主要变更

### 1. GitHub Actions 工作流程增强
- 在 `.github/workflows/jekyll-gh-pages.yml` 中添加了环境变量
- 使 Jekyll 能够访问 GitHub 仓库元数据

### 2. HTML 模板更新
- 在 `_layouts/default.html` 中添加了动态 GitHub 链接
- 在 footer 部分的 YouXam 链接后添加竖线分隔符和新链接
- 使用 Jekyll 的 `site.github` 变量动态生成仓库链接

### 3. 智能路径处理
- HTML 页面自动链接到对应的 MD 源文件
- 使用条件判断将 `.html` 后缀替换为 `.md`

### 4. JavaScript 优化
- 修改了 JavaScript 代码，让 GitHub 链接绕过自动的 `.md` 到 `.html` 转换
- 确保 GitHub 链接保持原始的 `.md` 格式

## ✨ 效果展示

- 每个页面底部都会显示：**"YouXam | 在 Github 中查看本页"**
- 点击链接可直接跳转到 GitHub 查看和编辑对应的源文件
- HTML 页面会正确链接到对应的 MD 源文件

## 🧪 测试验证

已在测试仓库 YouXamDev/note 中验证功能正常：
- ✅ 链接显示正确
- ✅ HTML 到 MD 的路径转换正常
- ✅ GitHub 链接可正常访问 

该 PR 完成了 https://github.com/YouXam/note/issues/4